### PR TITLE
Refactor Command key detection and event tap initialization

### DIFF
--- a/main.swift
+++ b/main.swift
@@ -57,6 +57,15 @@ enum CommandSide {
 /// 現在押下中のCommandキーの左右。解放時の切り替え判定に使用。
 var currentCommandSide: CommandSide = .none
 
+// MARK: - Event Flag Constants
+
+/// 左Commandキーを示すビット（NX_DEVICELCMDKEYMASK）
+let leftCommandBit: UInt64 = 0x08
+/// 右Commandキーを示すビット（NX_DEVICERCMDKEYMASK）
+let rightCommandBit: UInt64 = 0x10
+/// Commandキー全般（左右問わず）を示すマスク
+let commandMask = CGEventFlags.maskCommand.rawValue
+
 // MARK: - Event Tap
 
 /// CGEventTap の CFMachPort 参照を保持するための名前空間。
@@ -77,18 +86,11 @@ let eventCallback: CGEventTapCallBack = { _, type, event, _ -> Unmanaged<CGEvent
         if let port = Tap.machPort {
             CGEvent.tapEnable(tap: port, enable: true)
         }
-        return Unmanaged.passRetained(event)
+        return Unmanaged.passUnretained(event)
     }
 
     // イベントフラグの生値を取得。修飾キーの状態がビットフィールドで格納されている。
     let rawFlags = event.flags.rawValue
-
-    // 左Commandキーを示すビット（NX_DEVICELCMDKEYMASK）
-    let leftCommandBit: UInt64 = 0x08
-    // 右Commandキーを示すビット（NX_DEVICERCMDKEYMASK）
-    let rightCommandBit: UInt64 = 0x10
-    // Commandキー全般（左右問わず）を示すマスク
-    let commandMask = CGEventFlags.maskCommand.rawValue
 
     // 現在Commandキーが押されているかどうか
     let isCommand = (rawFlags & commandMask) != 0
@@ -113,6 +115,14 @@ let eventCallback: CGEventTapCallBack = { _, type, event, _ -> Unmanaged<CGEvent
                 // 両方同時押し等、判別不能
                 currentCommandSide = .none
             }
+        } else if isCommand && commandIsDown {
+            // === Command押下中に修飾キーが変化 ===
+            // 左右両方のCommandキーが同時に押されている場合、意図が曖昧なため切り替えを抑制する。
+            let isLeft = (rawFlags & leftCommandBit) != 0
+            let isRight = (rawFlags & rightCommandBit) != 0
+            if isLeft && isRight {
+                currentCommandSide = .none
+            }
         } else if !isCommand && commandIsDown {
             // === Command解放の瞬間 ===
             commandIsDown = false
@@ -132,7 +142,7 @@ let eventCallback: CGEventTapCallBack = { _, type, event, _ -> Unmanaged<CGEvent
             currentCommandSide = .none
         }
 
-        return Unmanaged.passRetained(event)
+        return Unmanaged.passUnretained(event)
     }
 
     // keyDown / keyUp イベント:
@@ -142,7 +152,7 @@ let eventCallback: CGEventTapCallBack = { _, type, event, _ -> Unmanaged<CGEvent
         otherKeyPressedDuringCommand = true
     }
 
-    return Unmanaged.passRetained(event)
+    return Unmanaged.passUnretained(event)
 }
 
 // MARK: - Main
@@ -157,18 +167,18 @@ let eventMask: CGEventMask =
 
 /// CGEventTap の作成を試みる。権限がない場合はプロンプトを表示し、5秒間隔でリトライする。
 /// CGEvent.tapCreate は権限がないと nil を返すため、これを権限判定に利用する。
-var tap: CFMachPort!
+func createEventTap() -> CFMachPort {
+    if let t = CGEvent.tapCreate(
+        tap: .cgSessionEventTap,
+        place: .headInsertEventTap,
+        options: .listenOnly,
+        eventsOfInterest: eventMask,
+        callback: eventCallback,
+        userInfo: nil
+    ) {
+        return t
+    }
 
-if let t = CGEvent.tapCreate(
-    tap: .cgSessionEventTap,
-    place: .headInsertEventTap,
-    options: .listenOnly,
-    eventsOfInterest: eventMask,
-    callback: eventCallback,
-    userInfo: nil
-) {
-    tap = t
-} else {
     // 権限がないのでプロンプトを表示してリトライ
     promptInputMonitoringPermission()
 
@@ -182,11 +192,12 @@ if let t = CGEvent.tapCreate(
             callback: eventCallback,
             userInfo: nil
         ) {
-            tap = t
-            break
+            return t
         }
     }
 }
+
+let tap = createEventTap()
 
 /// 作成した tap を保持し、コールバック内から再有効化できるようにする。
 Tap.machPort = tap


### PR DESCRIPTION
## Summary
This PR refactors the Command key detection logic and event tap initialization to improve code organization and fix memory management issues.

## Key Changes

- **Moved event flag constants to module level**: Extracted `leftCommandBit`, `rightCommandBit`, and `commandMask` from the event callback function to the top level for better reusability and clarity.

- **Fixed memory management**: Changed `Unmanaged.passRetained(event)` to `Unmanaged.passUnretained(event)` in three locations. The event tap callback should not retain the event as it's already managed by the system.

- **Added simultaneous Command key detection**: Implemented logic to detect when both left and right Command keys are pressed simultaneously during an active Command key press, setting `currentCommandSide` to `.none` to prevent ambiguous behavior.

- **Refactored event tap creation**: Extracted the event tap creation logic into a `createEventTap()` function that encapsulates the retry logic with permission prompting. This improves code organization and makes the initialization flow clearer.

## Implementation Details

The new `createEventTap()` function consolidates the tap creation attempt and retry loop, making the main execution flow more readable. The function returns a `CFMachPort` and handles permission prompting internally, eliminating the need for the previous conditional assignment pattern.

The additional Command key state check (`isCommand && commandIsDown`) prevents unintended behavior when both Command keys are pressed simultaneously, which could otherwise cause ambiguous switching behavior.

https://claude.ai/code/session_01Wo3RZwA9UM1JaWCasaM5cf