### PR TITLE
feat: add independent scroll direction reversal for mouse and trackpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A macOS menu bar resident app (input source switcher) that lets you choose betwe
 ## Table of Contents
 
 - [Switching Methods](#switching-methods)
+- [Scroll Direction Control](#scroll-direction-control)
 - [Features](#features)
 - [Specifications](#specifications)
 - [App Structure](#app-structure)
@@ -38,6 +39,19 @@ Reliably switches languages with a single key, regardless of the current state.
 
 > **Required setting when using the CapsLock method**
 > To prevent conflicts with macOS's built-in "Caps Lock" function (green light on), go to **System Settings > Keyboard > Keyboard Shortcuts > Modifier Keys** and set the "Caps Lock key" assignment to **"No Action"**. (Since this app uses its own hardware monitoring, the switching will work correctly even with the "No Action" setting.)
+
+## Scroll Direction Control
+
+Toggle **Reverse Mouse Scroll** from the menu bar to reverse the vertical scroll direction of **mouse wheel events only**. Trackpad scrolling follows macOS's own "Natural Scrolling" setting and is not touched.
+
+This lets you set "natural scrolling on trackpad, traditional on mouse" (or any other combination of the two), which macOS's built-in settings cannot express — its "Natural Scrolling" toggle applies to both devices at once.
+
+### Details
+
+- Mouse vs. trackpad is detected via the CGEvent `scrollPhase` / `momentumPhase` fields. Trackpad events carry phase information; mouse wheel events do not.
+- Trackpad events pass through untouched. For mouse events, all three Y-axis delta fields (pixel, line, fixed-point) are negated to stay consistent across apps.
+- The scroll event tap is only active while the option is on. Turning it off removes the tap entirely.
+- Horizontal scrolling is not affected. No additional permissions required.
 
 ## Features
 
@@ -347,6 +361,7 @@ Created by Toshiaki Kujime.
 ## 目次
 
 - [切り替え方式](#切り替え方式)
+- [スクロール方向制御](#スクロール方向制御)
 - [特徴](#特徴)
 - [仕様](#仕様)
 - [アプリの構造](#アプリの構造)
@@ -373,6 +388,19 @@ Created by Toshiaki Kujime.
 
 > **CapsLock方式を使用する場合の必須設定**
 > macOS標準の「大文字固定」機能（緑のランプ点灯）が競合して誤作動するのを防ぐため、**システム設定 > キーボード > キーボードショートカット > 修飾キー** にて、「Caps Lockキー」への割り当てを必ず **「アクションなし」** に設定してください。（本アプリは独自のハードウェア監視を使用しているため、「アクションなし」に設定しても正確に切り替えが作動します）
+
+## スクロール方向制御
+
+メニューバーの **Reverse Mouse Scroll** をONにすると、**マウスホイールのみ**の縦スクロール方向が反転します。トラックパッドのスクロールはmacOS標準の「ナチュラルスクロール」設定にそのまま従い、本アプリは介入しません。
+
+これにより、「トラックパッドはナチュラル、マウスは従来方向」のような組み合わせが実現できます（macOS標準の「ナチュラルスクロール」設定はマウスとトラックパッド両方に一律で効くため、この組み合わせは表現できません）。
+
+### 仕組み
+
+- マウス / トラックパッドの判別は CGEvent の `scrollPhase` / `momentumPhase` フィールドで行います。トラックパッドイベントにはフェーズ情報が付与され、マウスホイールイベントには付きません。
+- トラックパッドイベントは素通し。マウスイベントだけ Y軸の3種類のデルタ値（pixel、line、fixed-point）を全て符号反転します（アプリによって参照フィールドが異なるため）。
+- スクロールイベントtapはONのときだけ有効化されます。OFFにすると完全に解除されます。
+- 横スクロール（Axis2）は対象外。追加の権限は不要です。
 
 ## 特徴
 

--- a/main.swift
+++ b/main.swift
@@ -123,6 +123,7 @@ class EventInterceptor {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
         setupHIDManager()
+        setupScrollTap()
     }
 
     private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
@@ -194,14 +195,16 @@ class EventInterceptor {
     // MARK: - Scroll Direction Tap
 
     private func updateScrollTapState() {
-        if reverseMouseScroll && scrollTap == nil {
-            startScrollTap()
-        } else if !reverseMouseScroll && scrollTap != nil {
-            stopScrollTap()
+        if let tap = scrollTap {
+            CGEvent.tapEnable(tap: tap, enable: reverseMouseScroll)
+            print("Scroll event tap \(reverseMouseScroll ? "enabled" : "disabled").")
         }
     }
 
-    private func startScrollTap() {
+    /// 起動時に1回だけ呼ばれる。tapを作成し、reverseMouseScroll の初期値に従って enable/disable を設定する。
+    /// tap の作成/破棄を繰り返すと権限キャッシュが破損するリスクがあるため、
+    /// 以降は CGEvent.tapEnable で有効/無効を切り替える。
+    func setupScrollTap() {
         let eventMask: CGEventMask = 1 << CGEventType.scrollWheel.rawValue
 
         let callback: CGEventTapCallBack = { proxy, type, event, refcon in
@@ -226,20 +229,9 @@ class EventInterceptor {
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, t, 0)
         self.scrollRunLoopSource = source
         CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
-        CGEvent.tapEnable(tap: t, enable: true)
-        print("Scroll event tap enabled.")
-    }
-
-    private func stopScrollTap() {
-        if let tap = scrollTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-        }
-        if let source = scrollRunLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
-        }
-        scrollTap = nil
-        scrollRunLoopSource = nil
-        print("Scroll event tap disabled.")
+        // 初期状態は reverseMouseScroll に従う（デフォルト false → disabled）
+        CGEvent.tapEnable(tap: t, enable: reverseMouseScroll)
+        print("Scroll event tap created (initially \(reverseMouseScroll ? "enabled" : "disabled")).")
     }
 
     private func handleScrollEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
@@ -247,13 +239,18 @@ class EventInterceptor {
     {
         // tapが無効化されたら自動的に再有効化（フェイルセーフ）
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap = self.scrollTap {
+            if let tap = self.scrollTap, reverseMouseScroll {
                 CGEvent.tapEnable(tap: tap, enable: true)
             }
             return Unmanaged.passUnretained(event)
         }
 
         guard type == .scrollWheel else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        // 設定がOFFなら素通し（フェイルセーフ）
+        if !reverseMouseScroll {
             return Unmanaged.passUnretained(event)
         }
 

--- a/main.swift
+++ b/main.swift
@@ -61,6 +61,13 @@ class EventInterceptor {
     private var runLoopSource: CFRunLoopSource?
     private var hidManager: IOHIDManager?
 
+    // スクロール方向反転用（マウスのみ。トラックパッドはmacOS標準のナチュラルスクロール設定に従う）
+    private var scrollTap: CFMachPort?
+    private var scrollRunLoopSource: CFRunLoopSource?
+    var reverseMouseScroll: Bool = false {
+        didSet { updateScrollTapState() }
+    }
+
     func start() {
         let eventMask: CGEventMask =
             (1 << CGEventType.flagsChanged.rawValue) | (1 << CGEventType.keyDown.rawValue)
@@ -184,6 +191,97 @@ class EventInterceptor {
         return Unmanaged.passRetained(event)
     }
 
+    // MARK: - Scroll Direction Tap
+
+    private func updateScrollTapState() {
+        if reverseMouseScroll && scrollTap == nil {
+            startScrollTap()
+        } else if !reverseMouseScroll && scrollTap != nil {
+            stopScrollTap()
+        }
+    }
+
+    private func startScrollTap() {
+        let eventMask: CGEventMask = 1 << CGEventType.scrollWheel.rawValue
+
+        let callback: CGEventTapCallBack = { proxy, type, event, refcon in
+            guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
+            let interceptor = Unmanaged<EventInterceptor>.fromOpaque(refcon).takeUnretainedValue()
+            return interceptor.handleScrollEvent(proxy: proxy, type: type, event: event)
+        }
+
+        guard let t = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: callback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else {
+            print("Failed to create scroll event tap (needs Accessibility permission)")
+            return
+        }
+
+        self.scrollTap = t
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, t, 0)
+        self.scrollRunLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        CGEvent.tapEnable(tap: t, enable: true)
+        print("Scroll event tap enabled.")
+    }
+
+    private func stopScrollTap() {
+        if let tap = scrollTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = scrollRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        scrollTap = nil
+        scrollRunLoopSource = nil
+        print("Scroll event tap disabled.")
+    }
+
+    private func handleScrollEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent)
+        -> Unmanaged<CGEvent>?
+    {
+        // tapが無効化されたら自動的に再有効化（フェイルセーフ）
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = self.scrollTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard type == .scrollWheel else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        // マウスのみ反転。トラックパッドはmacOS標準のナチュラルスクロール設定に委ねる
+        // scrollPhase または momentumPhase が非0ならトラックパッド → 素通し
+        // マウスホイールはフェーズ情報を持たない（両方0）→ 反転対象
+        let scrollPhase = event.getIntegerValueField(.scrollWheelEventScrollPhase)
+        let momentumPhase = event.getIntegerValueField(.scrollWheelEventMomentumPhase)
+        let isTrackpad = (scrollPhase != 0 || momentumPhase != 0)
+
+        if isTrackpad {
+            return Unmanaged.passUnretained(event)
+        }
+
+        // 3種類のY軸フィールドを全て反転（アプリによって参照するフィールドが異なる）
+        // Axis1 = 縦スクロール、Axis2 = 横スクロール（今回は対象外）
+        let pixelDelta = event.getIntegerValueField(.scrollWheelEventPointDeltaAxis1)
+        event.setIntegerValueField(.scrollWheelEventPointDeltaAxis1, value: -pixelDelta)
+
+        let lineDelta = event.getIntegerValueField(.scrollWheelEventDeltaAxis1)
+        event.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: -lineDelta)
+
+        let fixedDelta = event.getDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1)
+        event.setDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1, value: -fixedDelta)
+
+        return Unmanaged.passUnretained(event)
+    }
+
     private func setupHIDManager() {
         hidManager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
         guard let hidManager = hidManager else { return }
@@ -294,6 +392,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
     var commandMenuItem: NSMenuItem!
     var capsLockMenuItem: NSMenuItem!
+    var reverseMouseMenuItem: NSMenuItem!
     var websiteMenuItem: NSMenuItem!
     var autoCheckMenuItem: NSMenuItem!
     var updateCheckTimer: Timer?
@@ -344,6 +443,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // --- セパレーター ---
         menu.addItem(NSMenuItem.separator())
 
+        // --- Reverse Mouse Scroll ---
+        reverseMouseMenuItem = NSMenuItem(
+            title: "Reverse Mouse Scroll", action: #selector(toggleReverseMouseScroll(_:)),
+            keyEquivalent: "")
+        reverseMouseMenuItem.target = self
+        let reverseMouse = UserDefaults.standard.bool(forKey: "reverseMouseScroll")
+        reverseMouseMenuItem.state = reverseMouse ? .on : .off
+        menu.addItem(reverseMouseMenuItem)
+
+        // --- セパレーター ---
+        menu.addItem(NSMenuItem.separator())
+
         // --- Check for Updates Automatically ---
         autoCheckMenuItem = NSMenuItem(
             title: "Check for Updates Automatically", action: #selector(toggleAutoCheck(_:)),
@@ -383,6 +494,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             capsLockMenuItem.state = .off
             interceptor.currentMode = .command
         }
+
+        // スクロール反転設定の復元（interceptor の didSet が scrollTap を有効化）
+        interceptor.reverseMouseScroll = reverseMouse
 
         // アップデートチェックのセットアップ
         updateChecker.onUpdateAvailable = { [weak self] version in
@@ -474,6 +588,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let button = statusItem.button {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
+    }
+
+    @objc func toggleReverseMouseScroll(_ sender: NSMenuItem) {
+        let newState = sender.state == .off
+        sender.state = newState ? .on : .off
+        UserDefaults.standard.set(newState, forKey: "reverseMouseScroll")
+        interceptor.reverseMouseScroll = newState
     }
 
     @objc func toggleAutoCheck(_ sender: NSMenuItem) {


### PR DESCRIPTION
## Summary

メニューバーに **Reverse Mouse Scroll** トグルを追加します。ONにするとマウスホイールの縦スクロール方向が反転します。トラックパッドのスクロールはmacOS標準の「ナチュラルスクロール」設定にそのまま従い、本アプリは介入しません。

これにより「トラックパッドはナチュラル、マウスは従来方向」のような組み合わせが実現できます（macOS標準設定は両デバイスに一律で効くため表現できない組み合わせです）。

## 実装

### CGEventTap

既存のキーボード監視tap（`.cgSessionEventTap` / `.listenOnly`）とは別に、スクロール専用tapを追加:

| 項目 | キーボードtap（既存） | スクロールtap（新規） |
|------|----------------------|----------------------|
| 種類 | `.cgSessionEventTap` | `.cghidEventTap` |
| 書き換え | `.listenOnly` | `.defaultTap` |
| イベント | `flagsChanged`, `keyDown`, `keyUp` | `scrollWheel` |

デルタ値の書き換えには `.defaultTap` が必須のため、既存tapには相乗りしていません。

### マウス判別

CGEvent の `scrollPhase` / `momentumPhase` フィールドで判別:

```swift
let scrollPhase = event.getIntegerValueField(.scrollWheelEventScrollPhase)
let momentumPhase = event.getIntegerValueField(.scrollWheelEventMomentumPhase)
let isTrackpad = (scrollPhase != 0 || momentumPhase != 0)
```

トラックパッドイベントにはフェーズ情報が付与され、マウスホイールイベントには付きません。トラックパッドと判定された場合は素通し。

### デルタ値反転

マウスと判定された場合のみ、Y軸の3種類のデルタフィールドを全て符号反転します（アプリによって参照フィールドが異なるため全て揃える）:

- `scrollWheelEventPointDeltaAxis1` (pixel)
- `scrollWheelEventDeltaAxis1` (line)
- `scrollWheelEventFixedPtDeltaAxis1` (fixed-point)

### Tapのライフサイクル

アプリ起動時に scroll tap を1回だけ作成し、`CGEvent.tapEnable` で有効/無効を切り替える。tap の作成/破棄を繰り返すと macOS の権限キャッシュが破損するリスクがあるため、ライフサイクルを通じて tap インスタンスは保持し続ける。OFF 時は tap が disabled なのでオーバーヘッドは無視できる。`tapDisabledByTimeout` / `tapDisabledByUserInput` への自動再有効化をフェイルセーフとして実装（既存キーボードtapと同じパターン）。

### 永続化

UserDefaults `reverseMouseScroll` (Bool, default `false`)。

### 権限

既存の入力監視権限で動作します。`.defaultTap` のためアクセシビリティ権限も必要になる場合があります。

### メニュー構造

```
Left/Right Command              ✓
CapsLock (Single/Double)
────────────────────────────
Reverse Mouse Scroll
────────────────────────────
Check for Updates Automatically ✓
About This App...
Quit EnJaSwitcher
```

## 注意点

- 横スクロール（Axis2）は対象外
- トラックパッドの挙動はmacOS標準設定に従う

## Test plan

- [ ] ビルドが通ること（`swiftc -O -o enja-switcher main.swift -framework Carbon -framework Cocoa -framework IOKit`）
- [ ] Reverse Mouse Scroll をONにしてマウスホイールの方向が反転すること
- [ ] ON/OFFどちらでもトラックパッドの挙動が変わらないこと（macOS標準設定に追従）
- [ ] 設定が UserDefaults に永続化され、再起動後も保持されること
- [ ] OFFの状態では scrollTap が disabled であり、スクロール方向に影響がないこと
- [ ] キーボード切り替え機能（Command / CapsLock）が引き続き正常に動作すること

https://claude.ai/code/session_014PtxVC8z7RWZ6e5RjiVCPP